### PR TITLE
Remove unnecessary usage of threading macros, use shorthand Java interop

### DIFF
--- a/src/hu/ssh/github_changelog/cli.clj
+++ b/src/hu/ssh/github_changelog/cli.clj
@@ -25,11 +25,12 @@
    ["-h" "--help"]])
 
 (defn- usage [summary]
-  (->> ["Usage: program-name [options...] <user/repo>"
-        ""
-        "Options:"
-        summary]
-       (join \newline)))
+  (join
+    \newline
+    ["Usage: program-name [options...] <user/repo>"
+     ""
+     "Options:"
+     summary]))
 
 (defn -main [& args]
   (let [{:keys [options arguments errors summary]} (cli/parse-opts args cli-options)

--- a/src/hu/ssh/github_changelog/core.clj
+++ b/src/hu/ssh/github_changelog/core.clj
@@ -33,8 +33,7 @@
    :post [(seq? %)]}
   (let [git (git/clone (util/git-url prefix user repo))
         tags (git/version-tags git)]
-    (->> (assoc-ranges tags)
-         (map (partial assoc-commits git)))))
+    (map (partial assoc-commits git) (assoc-ranges tags))))
 
 (def prefix "https://github.com")
 

--- a/src/hu/ssh/github_changelog/git.clj
+++ b/src/hu/ssh/github_changelog/git.clj
@@ -37,12 +37,12 @@
 (defn- get-merge-sha [repo tag]
   {:pre  [(repo? repo) (ref? tag)]
    :post [(string? %)]}
-  (let [peeled (. repo peel tag)]
-    (. (if-let [peeled-id (. peeled getPeeledObjectId)] peeled-id (. peeled getObjectId)) name)))
+  (let [peeled (.peel repo tag)]
+    (.name (if-let [peeled-id (.getPeeledObjectId peeled)] peeled-id (.getObjectId peeled)))))
 
 (defn- map-tag-name [tag]
   {:pre [(ref? tag)]}
-  (string/replace (. tag getName) #"^refs/tags/", ""))
+  (string/replace (.getName tag) #"^refs/tags/", ""))
 
 (defn- map-tag [repo tag]
   {:pre  [(repo? repo)]
@@ -57,7 +57,7 @@
 (defn tags [git]
   {:pre  [(git? git)]
    :post [(every? map? %)]}
-  (let [repo (. git getRepository)
+  (let [repo (.getRepository git)
         tags (.. git tagList call)]
     (map (partial map-tag repo) tags)))
 
@@ -72,7 +72,7 @@
 (defn- get-commit-sha [log]
   {:pre  [(commit? log)]
    :post [(string? %)]}
-  (. log name))
+  (.name log))
 
 (defn commits [git from until]
   {:pre  [(git? git) (string? until) (or (nil? from) (string? from))]

--- a/src/hu/ssh/github_changelog/github.clj
+++ b/src/hu/ssh/github_changelog/github.clj
@@ -8,5 +8,6 @@
 (defn fetch-pulls [user repo {:keys [token]}]
   {:pre  [(string? user) (string? repo)]
    :post [(seq? %)]}
-  (->> (pulls/pulls user repo (merge {:token token :all-pages true :state "closed"}))
-       (map #(assoc % :sha (pull-sha %)))))
+  (map
+    #(assoc % :sha  (pull-sha %))
+    (pulls/pulls user repo (merge {:token token, :all-pages true, :state  "closed"}))))


### PR DESCRIPTION
As reported by running `lein kibit`. (The basic rule is for macroexpansion, if the expanded code yields the same list as the non-macro version, then just use the simpler version. [Code](https://github.com/jonase/kibit/blob/master/src/kibit/rules/misc.clj#L91))